### PR TITLE
Disable color for test command

### DIFF
--- a/plugin/mix.vim
+++ b/plugin/mix.vim
@@ -46,7 +46,7 @@ command! -nargs=? Mdeps call s:Mdeps(<f-args>)
 
 function! s:Mtest()
   " TODO: load failures into the QuickFix list
-  call s:Mix('test')
+  call s:Mix('test --no-color')
 endfunction
 
 command! Mtest call s:Mtest()


### PR DESCRIPTION
This will allow more readable output while in graphical wrappers such as MacVim or GVim. See the current example output in MacVim below:

```
[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0
m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[
0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.
[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.
[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m

Finished in 5.8 seconds (3.4s on load, 2.3s on tests)
[32m40 tests, 0 failures[0
```